### PR TITLE
Add functionality to create / link group channels

### DIFF
--- a/src/main/java/de/nikos410/discordBot/modules/UserGroups.java
+++ b/src/main/java/de/nikos410/discordBot/modules/UserGroups.java
@@ -53,6 +53,60 @@ public class UserGroups {
         log.info(String.format("%s created new group %s.", Util.makeUserString(message.getAuthor(), message.getGuild()), groupName));
     }
 
+    @CommandSubscriber(command = "createGroupChannel", help = "Channel für Gruppe erstellen", pmAllowed = false, permissionLevel = CommandPermissions.MODERATOR)
+    public void command_createGroupChannel(final IMessage message, final String groupName, final String channelName) {
+        if (!usergroupsJSON.has(groupName)) {
+            Util.sendMessage(message.getChannel(), String.format(":x: Gruppe `%s` nicht gefunden!", groupName));
+            return;
+        }
+
+        final IGuild server = message.getGuild();
+        final IRole groupRole = server.getRoleByID(usergroupsJSON.getLong(groupName));
+        final IRole everyoneRole = server.getEveryoneRole();
+        final IRole modRole = server.getRoleByID(bot.configJSON.getLong("modRole"));
+        final IChannel channel = server.createChannel(channelName);
+
+        channel.overrideRolePermissions(groupRole, EnumSet.of(Permissions.READ_MESSAGES, Permissions.SEND_MESSAGES), EnumSet.noneOf(Permissions.class));
+        channel.overrideRolePermissions(modRole, EnumSet.of(Permissions.READ_MESSAGES, Permissions.SEND_MESSAGES), EnumSet.noneOf(Permissions.class));
+        channel.overrideRolePermissions(everyoneRole, EnumSet.noneOf(Permissions.class), EnumSet.of(Permissions.READ_MESSAGES, Permissions.SEND_MESSAGES));
+
+        Util.sendMessage(message.getChannel(), String.format(":white_check_mark: Channel '%s' für Gruppe `%s` erstellt.", channelName, groupName));
+        log.info(String.format("%s created new channel %s for group %s.", Util.makeUserString(message.getAuthor(), message.getGuild()), channelName, groupName));
+    }
+
+    @CommandSubscriber(command = "linkGroupChannel", help = "Bestehenden Channel mit Gruppe verknüpfen", pmAllowed = false, permissionLevel = CommandPermissions.MODERATOR)
+    public void command_linkGroupChannel(final IMessage message, final String groupName, final String channelIdString) {
+        if (!usergroupsJSON.has(groupName)) {
+            Util.sendMessage(message.getChannel(), String.format(":x: Gruppe `%s` nicht gefunden!", groupName));
+            return;
+        }
+
+        try {
+            final long channelId = Long.parseLong(channelIdString);
+            final IGuild server = message.getGuild();
+            final IRole groupRole = server.getRoleByID(usergroupsJSON.getLong(groupName));
+
+            final IChannel channelToLink = server.getChannelByID(channelId);
+            linkGroupChannel(message, groupRole, channelToLink);
+
+            final String channelName = channelToLink.getName();
+            Util.sendMessage(message.getChannel(), String.format(":white_check_mark: Bestehenden Channel '%s' mit Gruppe `%s` verknüpft.", channelName, groupName));
+            log.info(String.format("%s linked channel %s to group %s.", Util.makeUserString(message.getAuthor(), message.getGuild()), channelName, groupName));
+        } catch (final NumberFormatException e) {
+            Util.sendMessage(message.getChannel(), ":x: Channel ID konnte nicht geparsed werden!");
+        }
+    }
+
+    private void linkGroupChannel(final IMessage message, final IRole groupRole, final IChannel channelToLink) {
+        final IGuild server = message.getGuild();
+        final IRole everyoneRole = server.getEveryoneRole();
+        final IRole modRole = server.getRoleByID(bot.configJSON.getLong("modRole"));
+
+        channelToLink.overrideRolePermissions(groupRole, EnumSet.of(Permissions.READ_MESSAGES, Permissions.SEND_MESSAGES), EnumSet.noneOf(Permissions.class));
+        channelToLink.overrideRolePermissions(modRole, EnumSet.of(Permissions.READ_MESSAGES, Permissions.SEND_MESSAGES), EnumSet.noneOf(Permissions.class));
+        channelToLink.overrideRolePermissions(everyoneRole, EnumSet.noneOf(Permissions.class), EnumSet.of(Permissions.READ_MESSAGES, Permissions.SEND_MESSAGES));
+    }
+
     @CommandSubscriber(command = "removeGroup", help = "Gruppe entfernen", pmAllowed = false, permissionLevel = CommandPermissions.MODERATOR)
     public void command_removeGroup(final IMessage message, final String groupName) {
 
@@ -106,7 +160,7 @@ public class UserGroups {
         keyList.addAll(usergroupsJSON.keySet());
         Collections.sort(keyList);
 
-        for (String key : keyList) {
+        for (final String key : keyList) {
             if (stringBuilder.length() != 0) {
                 stringBuilder.append('\n');
             }


### PR DESCRIPTION
Use "[prefix]createGroupChannel [groupName] [channelName]" to create a channel to which only members of the given group (and moderators) have read/write access.

Use "[prefix]linkGroupChannel [groupName] [channelId]" to modify an existing channel so only members of the given group (and moderators) have read/write access.