### PR TITLE
New module: Last.fm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     compile group: 'io.sentry', name: 'sentry-logback', version: '1.7.15'
+    compile 'de.u-mass:lastfm-java:0.1.2'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile group: 'org.reflections', name: 'reflections', version: '0.9.11'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     compile group: 'io.sentry', name: 'sentry-logback', version: '1.7.15'
-    compile 'de.u-mass:lastfm-java:0.1.2'
+    compile group: 'de.u-mass', name: 'lastfm-java', version: '0.1.2'
 }
 
 repositories {

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -7,7 +7,6 @@ import de.nikos410.discordbot.framework.annotations.CommandSubscriber;
 import de.nikos410.discordbot.util.discord.DiscordIO;
 import de.nikos410.discordbot.util.io.IOUtil;
 import de.umass.lastfm.*;
-import de.umass.lastfm.cache.FileSystemCache;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -16,17 +15,21 @@ import sx.blah.discord.handle.obj.IMessage;
 import sx.blah.discord.util.EmbedBuilder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 
 @CommandModule(moduleName = "Last.fm", commandOnly = true)
 public class LastFm {
     private static final Logger LOG = LoggerFactory.getLogger(LastFm.class);
 
-    private static final Path FONT_PATH = Paths.get("data/Poly-Regular.otf");
-    private static final Path LASTFM_PATH = Paths.get("data/lastFm.json");
-    private static final Path CACHE_PATH = Paths.get("data/.last-fm-cache");
-    private static final Path TEMPIMG_PATH = Paths.get("data/chart.png");
+    private static final Path FONT_PATH = Paths.get("data/lastFm/Poly-Regular.otf");
+    private static final Path LASTFM_PATH = Paths.get("data/lastFm/lastFm.json");
+    private static final Path TEMP_IMG_PATH = Paths.get("data/lastFm/chart.png");
+
     private final JSONObject lastFmJSON;
+
+    private final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
     private String apiKey;
 
@@ -46,7 +49,6 @@ public class LastFm {
         }
 
         Caller.getInstance().setUserAgent("de-DiscordBot/1.0");
-        Caller.getInstance().setCache(new FileSystemCache(CACHE_PATH.toFile()));
     }
 
     @CommandSubscriber(command = "lastFmSetApiKey", help = "Last.fm API-Key setzen - nur für Admins", pmAllowed = false, permissionLevel = PermissionLevel.ADMIN)
@@ -66,30 +68,35 @@ public class LastFm {
 
             switch (args[0]) {
                 case "set":
-                    if (args[1] != null) {
+                    try {
                         setUsername(message, args[1]);
-                    } else {
+                    } catch (ArrayIndexOutOfBoundsException ex) {
                         DiscordIO.sendMessage(message.getChannel(), ":x: Keinen Last.fm-Usernamen angegeben.");
-                        return;
                     }
                     break;
                 case "now":
                     getNowPlaying(message);
                     break;
                 case "recent":
-                    getRecentTracks(message);
+                    getRecentTracks(message, 10);
                     break;
                 case "topartists":
+                    getTopArtists(message, 10);
                     break;
                 case "topalbums":
+                    getTopAlbums(message, 10);
                     break;
                 case "toptracks":
+                    getTopTracks(message, 10);
                     break;
                 case "weeklyartists":
+                    getWeeklyArtists(message, 10);
                     break;
                 case "weeklyalbums":
+                    getWeeklyAlbums(message, 10);
                     break;
                 case "weeklytracks":
+                    getWeeklyTracks(message, 10);
                     break;
                 case "collage":
                     break;
@@ -129,7 +136,7 @@ public class LastFm {
 
         embedBuilder.withColor(185, 0, 0);
         embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
-        embedBuilder.withAuthorName(String.format("Aktuell gespielter Track von %s", message.getAuthor().getNicknameForGuild(message.getGuild())));
+        embedBuilder.withAuthorName(String.format("Aktuell gespielter Track von %s", message.getAuthor().getDisplayName(message.getGuild())));
 
         int i = 1;
 
@@ -147,7 +154,7 @@ public class LastFm {
         DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
     }
 
-    private void getRecentTracks(final IMessage message) {
+    private void getRecentTracks(final IMessage message, final int limit) {
         String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
 
         Collection<Track> response = User.getRecentTracks(username, apiKey).getPageResults();
@@ -156,23 +163,207 @@ public class LastFm {
 
         embedBuilder.withColor(185, 0, 0);
         embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
-        embedBuilder.withAuthorName(String.format("Kürzlich gespielte Tracks von %s", message.getAuthor().getNicknameForGuild(message.getGuild())));
+        embedBuilder.withAuthorName(String.format("Kürzlich gespielte Tracks von %s", message.getAuthor().getDisplayName(message.getGuild())));
 
         int i = 1;
 
+        StringBuilder chart = new StringBuilder();
+
         for (Track track : response) {
-            if (i == 11)
+            if (i == limit + 1)
                 break;
 
-            embedBuilder.appendField("", String.format("`%d` **%s** - %s", i, track.getArtist(), track.getName()), false);
+            chart.append(String.format("`%s` **%s** - *%s*\n", i, track.getArtist(), track.getName()));
             i++;
         }
+
+        embedBuilder.withDesc(chart.toString());
 
         DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
     }
 
+    private void getTopArtists(final IMessage message, final int limit) {
+        String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
+
+        Collection<Artist> response = User.getTopArtists(username, apiKey);
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+
+        embedBuilder.withColor(185, 0, 0);
+        embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
+        embedBuilder.withAuthorName(String.format("Top-Künstler von %s", message.getAuthor().getDisplayName(message.getGuild())));
+
+        int i = 1;
+
+        StringBuilder chart = new StringBuilder();
+
+        for (Artist artist : response) {
+            if (i == limit + 1)
+                break;
+
+            chart.append(String.format("`%s` **%s** (%s mal gespielt)\n", i, artist.getName(), artist.getPlaycount()));
+            i++;
+        }
+
+        embedBuilder.withDesc(chart.toString());
+
+        DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
+    }
+
+    private void getTopAlbums(final IMessage message, final int limit) {
+        String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
+
+        Collection<Album> response = User.getTopAlbums(username, apiKey);
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+
+        embedBuilder.withColor(185, 0, 0);
+        embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
+        embedBuilder.withAuthorName(String.format("Top-Alben von %s", message.getAuthor().getDisplayName(message.getGuild())));
+
+        int i = 1;
+
+        StringBuilder chart = new StringBuilder();
+
+        for (Album album : response) {
+            if (i == limit + 1)
+                break;
+
+            chart.append(String.format("`%s` **%s** - *%s* (%s mal gespielt)\n", i, album.getArtist(), album.getName(), album.getPlaycount()));
+            i++;
+        }
+
+        embedBuilder.withDesc(chart.toString());
+
+        DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
+    }
+
+    private void getTopTracks(final IMessage message, final int limit) {
+        String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
+
+        Collection<Track> response = User.getTopTracks(username, apiKey);
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+
+        embedBuilder.withColor(185, 0, 0);
+        embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
+        embedBuilder.withAuthorName(String.format("Top-Titel von %s", message.getAuthor().getDisplayName(message.getGuild())));
+
+        int i = 1;
+
+        StringBuilder chart = new StringBuilder();
+
+        for (Track track : response) {
+            if (i == limit + 1)
+                break;
+
+            chart.append(String.format("`%s` **%s** - *%s* (%s mal gespielt)\n", i, track.getArtist(), track.getName(), track.getPlaycount()));
+            i++;
+        }
+
+        embedBuilder.withDesc(chart.toString());
+
+        DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
+    }
+
+    private void getWeeklyArtists(final IMessage message, final int limit) {
+        String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
+
+        Collection<Artist> response = User.getTopArtists(username, Period.WEEK, apiKey);
+
+        LocalDate toDate = LocalDate.now();
+        LocalDate fromDate = toDate.minusDays(7);
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+
+        embedBuilder.withColor(185, 0, 0);
+        embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
+        embedBuilder.withAuthorName(String.format("Top-Künstler von %s\n(Woche vom %s zum %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)));
+
+        int i = 1;
+
+        StringBuilder chart = new StringBuilder();
+
+        for (Artist artist : response) {
+            if (i == limit + 1)
+                break;
+
+            chart.append(String.format("`%s` **%s** (%s mal gespielt)\n", i, artist.getName(), artist.getPlaycount()));
+            i++;
+        }
+
+        embedBuilder.withDesc(chart.toString());
+
+        DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
+    }
+
+    private void getWeeklyAlbums(final IMessage message, final int limit) {
+        String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
+
+        Collection<Album> response = User.getTopAlbums(username, Period.WEEK, apiKey);
+
+        LocalDate toDate = LocalDate.now();
+        LocalDate fromDate = toDate.minusDays(7);
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+
+        embedBuilder.withColor(185, 0, 0);
+        embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
+        embedBuilder.withAuthorName(String.format("Top-Alben von %s\n(Woche vom %s zum %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)));
+
+        int i = 1;
+
+        StringBuilder chart = new StringBuilder();
+
+        for (Album album : response) {
+            if (i == limit + 1)
+                break;
+
+            chart.append(String.format("`%s` **%s** - *%s* (%s mal gespielt)\n", i, album.getArtist(), album.getName(), album.getPlaycount()));
+            i++;
+        }
+
+        embedBuilder.withDesc(chart.toString());
+
+        DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
+    }
+
+    private void getWeeklyTracks(final IMessage message, final int limit) {
+        String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
+
+        Collection<Track> response = User.getTopTracks(username, Period.WEEK, apiKey);
+
+        LocalDate toDate = LocalDate.now();
+        LocalDate fromDate = toDate.minusDays(7);
+
+        EmbedBuilder embedBuilder = new EmbedBuilder();
+
+        embedBuilder.withColor(185, 0, 0);
+        embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
+        embedBuilder.withAuthorName(String.format("Top-Titel von %s\n(Woche vom %s zum %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)));
+
+        int i = 1;
+
+        StringBuilder chart = new StringBuilder();
+
+        for (Track track : response) {
+            if (i == limit + 1)
+                break;
+
+            chart.append(String.format("`%s` **%s** - *%s* (%s mal gespielt)\n", i, track.getArtist(), track.getName(), track.getPlaycount()));
+            i++;
+        }
+
+        embedBuilder.withDesc(chart.toString());
+
+        DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
+    }
+
+    private void generateCollage(final IMessage message, final String target, final String dimensions) {
+
+    }
     private void saveJSON() {
-        LOG.debug("Saving Last.fm config file.");
+        LOG.info("Saving Last.fm config file.");
 
         final String jsonOutput = lastFmJSON.toString(4);
         IOUtil.writeToFile(LASTFM_PATH, jsonOutput);

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -502,8 +502,6 @@ public class LastFm {
     }
 
     private void generateAndSendAlbumCollage(final IMessage message, final String dimensions, final Collection<Album> apiResponse) {
-        message.getChannel().setTypingStatus(true);
-
         LocalDate toDate = LocalDate.now();
         LocalDate fromDate = toDate.minusDays(7);
 
@@ -525,6 +523,8 @@ public class LastFm {
 
         switch (dimensions) {
             case "3x3":
+                message.getChannel().setTypingStatus(true);
+
                 if (imgFile.exists())
                     imgFile.delete();
 
@@ -573,6 +573,8 @@ public class LastFm {
                 DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
                 break;
             case "4x4":
+                message.getChannel().setTypingStatus(true);
+
                 if (imgFile.exists())
                     imgFile.delete();
 
@@ -621,6 +623,8 @@ public class LastFm {
                 DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
                 break;
             case "5x5":
+                message.getChannel().setTypingStatus(true);
+
                 if (imgFile.exists())
                     imgFile.delete();
 
@@ -669,14 +673,12 @@ public class LastFm {
                 DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
                 break;
             default:
-                DiscordIO.sendMessage(message.getChannel(), ":x: Falsche Parameter angegeben.\n\nSyntax:\n[p]lastfm collage <albums|artists> <3x3|4x4|5x5>");
+                DiscordIO.sendMessage(message.getChannel(), String.format(":x: Falsche Parameter angegeben. '%slastfm help' für Hilfe.", botPrefix));
                 break;
         }
     }
 
     private void generateAndSendArtistCollage(final IMessage message, final String dimensions, final Collection<Artist> apiResponse) {
-        message.getChannel().setTypingStatus(true);
-
         LocalDate toDate = LocalDate.now();
         LocalDate fromDate = toDate.minusDays(7);
 
@@ -698,6 +700,8 @@ public class LastFm {
 
         switch (dimensions) {
             case "3x3":
+                message.getChannel().setTypingStatus(true);
+
                 if (imgFile.exists())
                     imgFile.delete();
 
@@ -746,6 +750,8 @@ public class LastFm {
                 DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
                 break;
             case "4x4":
+                message.getChannel().setTypingStatus(true);
+
                 if (imgFile.exists())
                     imgFile.delete();
 
@@ -794,6 +800,8 @@ public class LastFm {
                 DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
                 break;
             case "5x5":
+                message.getChannel().setTypingStatus(true);
+
                 if (imgFile.exists())
                     imgFile.delete();
 
@@ -842,7 +850,7 @@ public class LastFm {
                 DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
                 break;
             default:
-                DiscordIO.sendMessage(message.getChannel(), ":x: Falsche Parameter angegeben.\n\nSyntax:\n[p]lastfm collage <albums|artists> <3x3|4x4|5x5>");
+                DiscordIO.sendMessage(message.getChannel(), String.format(":x: Falsche Parameter angegeben. '%slastfm help' für Hilfe.", botPrefix));
                 break;
         }
     }

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -1,5 +1,6 @@
 package de.nikos410.discordbot.modules;
 
+import de.nikos410.discordbot.DiscordBot;
 import de.nikos410.discordbot.exception.InitializationException;
 import de.nikos410.discordbot.framework.PermissionLevel;
 import de.nikos410.discordbot.framework.annotations.CommandModule;
@@ -34,6 +35,8 @@ public class LastFm {
     private static final Path LASTFM_PATH = Paths.get("data/lastFm/lastFm.json");
     private static final Path TEMP_IMG_PATH = Paths.get("data/lastFm/chart.png");
 
+    private final DiscordBot bot;
+
     private final JSONObject lastFmJSON;
 
     private final ArrayList<Integer[]> coords3x3 = new ArrayList<>();
@@ -44,7 +47,9 @@ public class LastFm {
 
     private String apiKey;
 
-    public LastFm() {
+    public LastFm(final DiscordBot bot) {
+        this.bot = bot;
+
         final String jsonContent = IOUtil.readFile(LASTFM_PATH);
         if (jsonContent == null) {
             throw new InitializationException("Could not read module data.", LastFm.class);
@@ -126,7 +131,7 @@ public class LastFm {
         DiscordIO.sendMessage(message.getChannel(), ":white_check_mark: Last.fm API-Key gesetzt.");
     }
 
-    @CommandSubscriber(command = "lastfm", help = "Last.fm Modul", pmAllowed = false)
+    @CommandSubscriber(command = "lastfm", help = "Last.fm Modul - Parameter 'help' für Hilfe", pmAllowed = false)
     public void command_lastfm(final IMessage message, final String argString) {
         if (!apiKey.equals("")) {
             final String[] args = argString.trim().split(" ");
@@ -142,7 +147,7 @@ public class LastFm {
                 case "now":
                     getNowPlaying(message);
                     break;
-                case "recent":
+                case "recenttracks":
                     getRecentTracks(message, 10);
                     break;
                 case "topartists":
@@ -171,6 +176,21 @@ public class LastFm {
                     }
                     break;
                 case "help":
+                    String msg = "```Last.fm Modul - Hilfe\n\n"
+                    + String.format("'%slastfm set <last.fm username>' um deinen Last.fm-Nutzernamen zu setzen.\n\n", bot.configJSON.getString("prefix"))
+                    + "Verfügbare Parameter:\n\n"
+                    + "now\n"
+                    + "recenttracks\n"
+                    + "topartists\n"
+                    + "topalbums\n"
+                    + "toptracks\n"
+                    + "weeklyartists\n"
+                    + "weeklyalbums\n"
+                    + "weeklytracks\n"
+                    + "collage <artists|albums> <3x3|4x4|5x5>"
+                    + "```";
+
+                    DiscordIO.sendMessage(message.getChannel(), msg);
                     break;
                 default:
                     DiscordIO.sendMessage(message.getChannel(), ":x: Keine gültigen Parameter angegeben.");

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -13,21 +13,32 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sx.blah.discord.handle.obj.IMessage;
 import sx.blah.discord.util.EmbedBuilder;
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collection;
 
 @CommandModule(moduleName = "Last.fm", commandOnly = true)
 public class LastFm {
     private static final Logger LOG = LoggerFactory.getLogger(LastFm.class);
 
-    private static final Path FONT_PATH = Paths.get("data/lastFm/Poly-Regular.otf");
+    private static final Path ERROR_IMG_PATH = Paths.get("data/lastFm/error-icon.png");
     private static final Path LASTFM_PATH = Paths.get("data/lastFm/lastFm.json");
     private static final Path TEMP_IMG_PATH = Paths.get("data/lastFm/chart.png");
 
     private final JSONObject lastFmJSON;
+
+    private final ArrayList<Integer[]> coords3x3 = new ArrayList<>();
+    private final ArrayList<Integer[]> coords4x4 = new ArrayList<>();
+    private final ArrayList<Integer[]> coords5x5 = new ArrayList<>();
 
     private final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("dd.MM.yyyy");
 
@@ -49,6 +60,60 @@ public class LastFm {
         }
 
         Caller.getInstance().setUserAgent("de-DiscordBot/1.0");
+
+        // Coordinate initialization for collage generation
+        coords3x3.add(new Integer[]{100, 400, 1801, 445});
+        coords3x3.add(new Integer[]{667, 400, 1801, 553});
+        coords3x3.add(new Integer[]{1234, 400, 1801, 661});
+        coords3x3.add(new Integer[]{100, 967, 1801, 1012});
+        coords3x3.add(new Integer[]{667, 967, 1801, 1120});
+        coords3x3.add(new Integer[]{1234, 967, 1801, 1228});
+        coords3x3.add(new Integer[]{100, 1534, 1801, 1579});
+        coords3x3.add(new Integer[]{667, 1534, 1801, 1687});
+        coords3x3.add(new Integer[]{1234, 1534, 1801, 1795});
+
+        coords4x4.add(new Integer[]{100, 400, 1801, 445});
+        coords4x4.add(new Integer[]{525, 400, 1801, 523});
+        coords4x4.add(new Integer[]{950, 400, 1801, 601});
+        coords4x4.add(new Integer[]{1375, 400, 1801, 679});
+        coords4x4.add(new Integer[]{100, 825, 1801, 870});
+        coords4x4.add(new Integer[]{525, 825, 1801, 948});
+        coords4x4.add(new Integer[]{950, 825, 1801, 1026});
+        coords4x4.add(new Integer[]{1375, 825, 1801, 1104});
+        coords4x4.add(new Integer[]{100, 1250, 1801, 1295});
+        coords4x4.add(new Integer[]{525, 1250, 1801, 1373});
+        coords4x4.add(new Integer[]{950, 1250, 1801, 1451});
+        coords4x4.add(new Integer[]{1375, 1250, 1801, 1529});
+        coords4x4.add(new Integer[]{100, 1675, 1801, 1720});
+        coords4x4.add(new Integer[]{525, 1675, 1801, 1798});
+        coords4x4.add(new Integer[]{950, 1675, 1801, 1874});
+        coords4x4.add(new Integer[]{1375, 1675, 1801, 1954});
+
+        coords5x5.add(new Integer[]{100, 400, 1801, 445});
+        coords5x5.add(new Integer[]{440, 400, 1801, 503});
+        coords5x5.add(new Integer[]{780, 400, 1801, 561});
+        coords5x5.add(new Integer[]{1120, 400, 1801, 619});
+        coords5x5.add(new Integer[]{1460, 400, 1801, 678});
+        coords5x5.add(new Integer[]{100, 740, 1801, 785});
+        coords5x5.add(new Integer[]{440, 740, 1801, 843});
+        coords5x5.add(new Integer[]{780, 740, 1801, 901});
+        coords5x5.add(new Integer[]{1120, 740, 1801, 959});
+        coords5x5.add(new Integer[]{1460, 740, 1801, 1017});
+        coords5x5.add(new Integer[]{100, 1080, 1801, 1125});
+        coords5x5.add(new Integer[]{440, 1080, 1801, 1183});
+        coords5x5.add(new Integer[]{780, 1080, 1801, 1241});
+        coords5x5.add(new Integer[]{1120, 1080, 1801, 1299});
+        coords5x5.add(new Integer[]{1460, 1080, 1801, 1357});
+        coords5x5.add(new Integer[]{100, 1420, 1801, 1465});
+        coords5x5.add(new Integer[]{440, 1420, 1801, 1523});
+        coords5x5.add(new Integer[]{780, 1420, 1801, 1581});
+        coords5x5.add(new Integer[]{1120, 1420, 1801, 1639});
+        coords5x5.add(new Integer[]{1460, 1420, 1801, 1697});
+        coords5x5.add(new Integer[]{100, 1760, 1801, 1805});
+        coords5x5.add(new Integer[]{440, 1760, 1801, 1863});
+        coords5x5.add(new Integer[]{780, 1760, 1801, 1921});
+        coords5x5.add(new Integer[]{1120, 1760, 1801, 1979});
+        coords5x5.add(new Integer[]{1460, 1760, 1801, 2037});
     }
 
     @CommandSubscriber(command = "lastFmSetApiKey", help = "Last.fm API-Key setzen - nur für Admins", pmAllowed = false, permissionLevel = PermissionLevel.ADMIN)
@@ -99,6 +164,11 @@ public class LastFm {
                     getWeeklyTracks(message, 10);
                     break;
                 case "collage":
+                    try {
+                        sendCollage(message, args[1], args[2]);
+                    } catch (ArrayIndexOutOfBoundsException ex) {
+                        DiscordIO.sendMessage(message.getChannel(), ":x: Falsche Parameter angegeben.\n\nSyntax:\n[p]lastfm collage <albums|artists> <3x3|4x4|5x5>");
+                    }
                     break;
                 case "help":
                     break;
@@ -359,9 +429,370 @@ public class LastFm {
         DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
     }
 
-    private void generateCollage(final IMessage message, final String target, final String dimensions) {
+    private void sendCollage(final IMessage message, final String target, final String dimensions) {
+        String username = lastFmJSON.getJSONObject("users").getString(message.getAuthor().getStringID());
 
+        switch (target) {
+            case "albums":
+                Collection<Album> responseAlbum = User.getTopAlbums(username, Period.WEEK, apiKey);
+                generateAndSendAlbumCollage(message, dimensions, responseAlbum);
+                break;
+            case "artists":
+                Collection<Artist> responseArtist = User.getTopArtists(username, Period.WEEK, apiKey);
+                generateAndSendArtistCollage(message, dimensions, responseArtist);
+                break;
+            default:
+                DiscordIO.sendMessage(message.getChannel(), ":x: Falsche Parameter angegeben.\n\nSyntax:\n[p]lastfm collage <albums|artists> <3x3|4x4|5x5>");
+                break;
+        }
     }
+
+    private void generateAndSendAlbumCollage(final IMessage message, final String dimensions, final Collection<Album> apiResponse) {
+        message.getChannel().setTypingStatus(true);
+
+        LocalDate toDate = LocalDate.now();
+        LocalDate fromDate = toDate.minusDays(7);
+
+        File imgFile = TEMP_IMG_PATH.toFile();
+
+        java.awt.Image errorImg;
+
+        try {
+            errorImg = ImageIO.read(ERROR_IMG_PATH.toFile());
+        } catch (IOException ex) {
+            LOG.error("Couldn't find error image.", ex);
+            return;
+        }
+
+        BufferedImage img;
+        Graphics2D g;
+
+        int i;
+
+        switch (dimensions) {
+            case "3x3":
+                if (imgFile.exists())
+                    imgFile.delete();
+
+                img = new BufferedImage(3200, 2300, BufferedImage.TYPE_INT_ARGB);
+
+                g = img.createGraphics();
+
+                g.setPaint(new Color(0,0,0));
+                g.fillRect(0,0, img.getWidth(), img.getHeight());
+
+                g.setPaint(new Color(255,255,255));
+                g.setFont(new Font("Arial", Font.PLAIN, 96));
+                g.drawString(String.format("Album-Charts von %s (%s - %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)), 100, 200);
+
+                i = 0;
+
+                g.setFont(new Font("Arial", Font.PLAIN, 48));
+
+                for (Album album : apiResponse) {
+                    if (i == 9)
+                        break;
+
+                    java.awt.Image albumImg;
+
+                    try {
+                        albumImg = ImageIO.read(new URL(album.getImageURL(ImageSize.LARGE)));
+                    } catch (Exception ex) {
+                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead", ex);
+                        albumImg = errorImg;
+                    }
+
+                    g.drawImage(albumImg, coords3x3.get(i)[0], coords3x3.get(i)[1], 517, 517, null);
+                    g.drawString(String.format("%s - %s", album.getArtist(), album.getName()), coords3x3.get(i)[2], coords3x3.get(i)[3]);
+
+                    i++;
+                }
+
+                try {
+                    ImageIO.write(img, "png", imgFile);
+                } catch (IOException ex) {
+                    LOG.error("ERROR while trying to write finished collage.", ex);
+                    message.getChannel().setTypingStatus(false);
+                    break;
+                }
+
+                DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
+                break;
+            case "4x4":
+                if (imgFile.exists())
+                    imgFile.delete();
+
+                img = new BufferedImage(3200, 2300, BufferedImage.TYPE_INT_ARGB);
+
+                g = img.createGraphics();
+
+                g.setPaint(new Color(0,0,0));
+                g.fillRect(0,0, img.getWidth(), img.getHeight());
+
+                g.setPaint(new Color(255,255,255));
+                g.setFont(new Font("Arial", Font.PLAIN, 96));
+                g.drawString(String.format("Album-Charts von %s (%s - %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)), 100, 200);
+
+                i = 0;
+
+                g.setFont(new Font("Arial", Font.PLAIN, 48));
+
+                for (Album album : apiResponse) {
+                    if (i == 16)
+                        break;
+
+                    java.awt.Image albumImg;
+
+                    try {
+                        albumImg = ImageIO.read(new URL(album.getImageURL(ImageSize.LARGE)));
+                    } catch (Exception ex) {
+                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead", ex);
+                        albumImg = errorImg;
+                    }
+
+                    g.drawImage(albumImg, coords4x4.get(i)[0], coords4x4.get(i)[1], 375, 375, null);
+                    g.drawString(String.format("%s - %s", album.getArtist(), album.getName()), coords4x4.get(i)[2], coords4x4.get(i)[3]);
+
+                    i++;
+                }
+
+                try {
+                    ImageIO.write(img, "png", imgFile);
+                } catch (IOException ex) {
+                    LOG.error("ERROR while trying to write finished collage.", ex);
+                    message.getChannel().setTypingStatus(false);
+                    break;
+                }
+
+                DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
+                break;
+            case "5x5":
+                if (imgFile.exists())
+                    imgFile.delete();
+
+                img = new BufferedImage(3200, 2300, BufferedImage.TYPE_INT_ARGB);
+
+                g = img.createGraphics();
+
+                g.setPaint(new Color(0,0,0));
+                g.fillRect(0,0, img.getWidth(), img.getHeight());
+
+                g.setPaint(new Color(255,255,255));
+                g.setFont(new Font("Arial", Font.PLAIN, 96));
+                g.drawString(String.format("Album-Charts von %s (%s - %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)), 100, 200);
+
+                i = 0;
+
+                g.setFont(new Font("Arial", Font.PLAIN, 48));
+
+                for (Album album : apiResponse) {
+                    if (i == 25)
+                        break;
+
+                    java.awt.Image albumImg;
+
+                    try {
+                        albumImg = ImageIO.read(new URL(album.getImageURL(ImageSize.LARGE)));
+                    } catch (Exception ex) {
+                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead", ex);
+                        albumImg = errorImg;
+                    }
+
+                    g.drawImage(albumImg, coords5x5.get(i)[0], coords5x5.get(i)[1], 290, 290, null);
+                    g.drawString(String.format("%s - %s", album.getArtist(), album.getName()), coords5x5.get(i)[2], coords5x5.get(i)[3]);
+
+                    i++;
+                }
+
+                try {
+                    ImageIO.write(img, "png", imgFile);
+                } catch (IOException ex) {
+                    LOG.error("ERROR while trying to write finished collage.", ex);
+                    message.getChannel().setTypingStatus(false);
+                    break;
+                }
+
+                DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
+                break;
+            default:
+                DiscordIO.sendMessage(message.getChannel(), ":x: Falsche Parameter angegeben.\n\nSyntax:\n[p]lastfm collage <albums|artists> <3x3|4x4|5x5>");
+                break;
+        }
+    }
+
+    private void generateAndSendArtistCollage(final IMessage message, final String dimensions, final Collection<Artist> apiResponse) {
+        message.getChannel().setTypingStatus(true);
+
+        LocalDate toDate = LocalDate.now();
+        LocalDate fromDate = toDate.minusDays(7);
+
+        File imgFile = TEMP_IMG_PATH.toFile();
+
+        java.awt.Image errorImg;
+
+        try {
+            errorImg = ImageIO.read(ERROR_IMG_PATH.toFile());
+        } catch (IOException ex) {
+            LOG.error("Couldn't find error image.", ex);
+            return;
+        }
+
+        BufferedImage img;
+        Graphics2D g;
+
+        int i;
+
+        switch (dimensions) {
+            case "3x3":
+                if (imgFile.exists())
+                    imgFile.delete();
+
+                img = new BufferedImage(3200, 2300, BufferedImage.TYPE_INT_ARGB);
+
+                g = img.createGraphics();
+
+                g.setPaint(new Color(0,0,0));
+                g.fillRect(0,0, img.getWidth(), img.getHeight());
+
+                g.setPaint(new Color(255,255,255));
+                g.setFont(new Font("Arial", Font.PLAIN, 96));
+                g.drawString(String.format("Künstler-Charts von %s (%s - %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)), 100, 200);
+
+                i = 0;
+
+                g.setFont(new Font("Arial", Font.PLAIN, 48));
+
+                for (Artist artist : apiResponse) {
+                    if (i == 9)
+                        break;
+
+                    java.awt.Image albumImg;
+
+                    try {
+                        albumImg = ImageIO.read(new URL(artist.getImageURL(ImageSize.LARGE)));
+                    } catch (Exception ex) {
+                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead", ex);
+                        albumImg = errorImg;
+                    }
+
+                    g.drawImage(albumImg, coords3x3.get(i)[0], coords3x3.get(i)[1], 517, 517, null);
+                    g.drawString(String.format("%s (%s mal gespielt)", artist.getName(), artist.getPlaycount()), coords3x3.get(i)[2], coords3x3.get(i)[3]);
+
+                    i++;
+                }
+
+                try {
+                    ImageIO.write(img, "png", imgFile);
+                } catch (IOException ex) {
+                    LOG.error("ERROR while trying to write finished collage.", ex);
+                    message.getChannel().setTypingStatus(false);
+                    break;
+                }
+
+                DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
+                break;
+            case "4x4":
+                if (imgFile.exists())
+                    imgFile.delete();
+
+                img = new BufferedImage(3200, 2300, BufferedImage.TYPE_INT_ARGB);
+
+                g = img.createGraphics();
+
+                g.setPaint(new Color(0,0,0));
+                g.fillRect(0,0, img.getWidth(), img.getHeight());
+
+                g.setPaint(new Color(255,255,255));
+                g.setFont(new Font("Arial", Font.PLAIN, 96));
+                g.drawString(String.format("Künstler-Charts von %s (%s - %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)), 100, 200);
+
+                i = 0;
+
+                g.setFont(new Font("Arial", Font.PLAIN, 48));
+
+                for (Artist artist : apiResponse) {
+                    if (i == 16)
+                        break;
+
+                    java.awt.Image albumImg;
+
+                    try {
+                        albumImg = ImageIO.read(new URL(artist.getImageURL(ImageSize.LARGE)));
+                    } catch (Exception ex) {
+                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead", ex);
+                        albumImg = errorImg;
+                    }
+
+                    g.drawImage(albumImg, coords4x4.get(i)[0], coords4x4.get(i)[1], 375, 375, null);
+                    g.drawString(String.format("%s (%s mal gespielt)", artist.getName(), artist.getPlaycount()), coords4x4.get(i)[2], coords4x4.get(i)[3]);
+
+                    i++;
+                }
+
+                try {
+                    ImageIO.write(img, "png", imgFile);
+                } catch (IOException ex) {
+                    LOG.error("ERROR while trying to write finished collage.", ex);
+                    message.getChannel().setTypingStatus(false);
+                    break;
+                }
+
+                DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
+                break;
+            case "5x5":
+                if (imgFile.exists())
+                    imgFile.delete();
+
+                img = new BufferedImage(3200, 2300, BufferedImage.TYPE_INT_ARGB);
+
+                g = img.createGraphics();
+
+                g.setPaint(new Color(0,0,0));
+                g.fillRect(0,0, img.getWidth(), img.getHeight());
+
+                g.setPaint(new Color(255,255,255));
+                g.setFont(new Font("Arial", Font.PLAIN, 96));
+                g.drawString(String.format("Künstler-Charts von %s (%s - %s)", message.getAuthor().getDisplayName(message.getGuild()), fromDate.format(dateFormat), toDate.format(dateFormat)), 100, 200);
+
+                i = 0;
+
+                g.setFont(new Font("Arial", Font.PLAIN, 48));
+
+                for (Artist artist : apiResponse) {
+                    if (i == 25)
+                        break;
+
+                    java.awt.Image albumImg;
+
+                    try {
+                        albumImg = ImageIO.read(new URL(artist.getImageURL(ImageSize.LARGE)));
+                    } catch (Exception ex) {
+                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead", ex);
+                        albumImg = errorImg;
+                    }
+
+                    g.drawImage(albumImg, coords5x5.get(i)[0], coords5x5.get(i)[1], 290, 290, null);
+                    g.drawString(String.format("%s (%s mal gespielt)", artist.getName(), artist.getPlaycount()), coords5x5.get(i)[2], coords5x5.get(i)[3]);
+
+                    i++;
+                }
+
+                try {
+                    ImageIO.write(img, "png", imgFile);
+                } catch (IOException ex) {
+                    LOG.error("ERROR while trying to write finished collage.", ex);
+                    message.getChannel().setTypingStatus(false);
+                    break;
+                }
+
+                DiscordIO.sendFile(message.getChannel(), message.getAuthor().mention(), TEMP_IMG_PATH.toFile());
+                break;
+            default:
+                DiscordIO.sendMessage(message.getChannel(), ":x: Falsche Parameter angegeben.\n\nSyntax:\n[p]lastfm collage <albums|artists> <3x3|4x4|5x5>");
+                break;
+        }
+    }
+
     private void saveJSON() {
         LOG.info("Saving Last.fm config file.");
 

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 public class LastFm {
     private static final Logger LOG = LoggerFactory.getLogger(LastFm.class);
 
+    // Download here: https://www.freeiconspng.com/uploads/error-icon-4.png and leave in specified path.
     private static final Path ERROR_IMG_PATH = Paths.get("data/lastFm/error-icon.png");
     private static final Path LASTFM_PATH = Paths.get("data/lastFm/lastFm.json");
     private static final Path TEMP_IMG_PATH = Paths.get("data/lastFm/chart.png");

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -1,0 +1,103 @@
+package de.nikos410.discordbot.modules;
+
+import de.nikos410.discordbot.exception.InitializationException;
+import de.nikos410.discordbot.framework.PermissionLevel;
+import de.nikos410.discordbot.framework.annotations.CommandModule;
+import de.nikos410.discordbot.framework.annotations.CommandSubscriber;
+import de.nikos410.discordbot.util.discord.DiscordIO;
+import de.nikos410.discordbot.util.io.IOUtil;
+import de.umass.lastfm.Caller;
+import de.umass.lastfm.User;
+import de.umass.lastfm.cache.FileSystemCache;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sx.blah.discord.handle.obj.IMessage;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@CommandModule(moduleName = "Last.fm", commandOnly = true)
+public class LastFm {
+    private static final Logger LOG = LoggerFactory.getLogger(LastFm.class);
+
+    private static final Path FONT_PATH = Paths.get("data/Poly-Regular.otf");
+    private static final Path LASTFM_PATH = Paths.get("data/lastFm.json");
+    private static final Path CACHE_PATH = Paths.get("data/.last-fm-cache");
+    private final JSONObject lastFmJSON;
+
+    private final String apiKey;
+
+    public LastFm () {
+        final String jsonContent = IOUtil.readFile(LASTFM_PATH);
+        if (jsonContent == null) {
+            throw new InitializationException("Could not read module data.", LastFm.class);
+        }
+        this.lastFmJSON = new JSONObject(jsonContent);
+        LOG.info("Loaded Last.fm config file.");
+
+        this.apiKey = lastFmJSON.getString("apiKey");
+
+        Caller.getInstance().setUserAgent("de-DiscordBot/1.0");
+        Caller.getInstance().setCache(new FileSystemCache(CACHE_PATH.toFile()));
+    }
+
+    @CommandSubscriber(command = "lastfm", help = "Last.fm Modul", pmAllowed = false)
+    public void command_lastfm(final IMessage message, final String argString) {
+        final String[] args = argString.split(" ");
+
+        switch (args[0]) {
+            case "set":
+                if (args[1] != null) {
+                    User response = User.getInfo(args[1], apiKey);
+
+                    if (response != null) {
+                        try {
+                            lastFmJSON.getJSONObject("users").put(message.getAuthor().getStringID(), args[1]);
+                        } catch (JSONException ex) {
+                            lastFmJSON.put("users", new JSONObject().put(message.getAuthor().getStringID(), args[1]));
+                        }
+                        saveJSON();
+                    } else {
+                        DiscordIO.sendMessage(message.getChannel(), ":x: Ungültigen Last.fm-Usernamen angegeben.");
+                        return;
+                    }
+                } else {
+                    DiscordIO.sendMessage(message.getChannel(), ":x: Keinen Last.fm-Usernamen angegeben.");
+                    return;
+                }
+                break;
+            case "recent":
+                break;
+            case "topartists":
+                break;
+            case "topalbums":
+                break;
+            case "toptracks":
+                break;
+            case "weeklyartists":
+                break;
+            case "weeklyalbums":
+                break;
+            case "weeklytracks":
+                break;
+            case "collage":
+                break;
+            case "help":
+                break;
+            default:
+                DiscordIO.sendMessage(message.getChannel(), ":x: Keine Parameter angegeben.");
+                return;
+        }
+    }
+
+    private void saveJSON() {
+        LOG.debug("Saving Last.fm config file.");
+
+        final String jsonOutput = lastFmJSON.toString(4);
+        IOUtil.writeToFile(LASTFM_PATH, jsonOutput);
+    }
+}

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -648,7 +648,7 @@ public class LastFm {
                     try {
                         albumImg = ImageIO.read(new URL(album.getImageURL(ImageSize.LARGE)));
                     } catch (Exception ex) {
-                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead", ex);
+                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead");
                         albumImg = errorImg;
                     }
 
@@ -725,7 +725,7 @@ public class LastFm {
                     try {
                         albumImg = ImageIO.read(new URL(artist.getImageURL(ImageSize.LARGE)));
                     } catch (Exception ex) {
-                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead", ex);
+                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead");
                         albumImg = errorImg;
                     }
 
@@ -773,7 +773,7 @@ public class LastFm {
                     try {
                         albumImg = ImageIO.read(new URL(artist.getImageURL(ImageSize.LARGE)));
                     } catch (Exception ex) {
-                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead", ex);
+                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead");
                         albumImg = errorImg;
                     }
 
@@ -821,7 +821,7 @@ public class LastFm {
                     try {
                         albumImg = ImageIO.read(new URL(artist.getImageURL(ImageSize.LARGE)));
                     } catch (Exception ex) {
-                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead", ex);
+                        LOG.info("Bad url while fetching artist image for collage generation - putting in error image instead");
                         albumImg = errorImg;
                     }
 

--- a/src/main/java/de/nikos410/discordbot/modules/LastFm.java
+++ b/src/main/java/de/nikos410/discordbot/modules/LastFm.java
@@ -230,20 +230,17 @@ public class LastFm {
             embedBuilder.withAuthorIcon(message.getAuthor().getAvatarURL());
             embedBuilder.withAuthorName(String.format("Aktuell gespielter Track von %s", message.getAuthor().getDisplayName(message.getGuild())));
 
-            int i = 1;
+            Track track = response.iterator().next();
 
-            for (Track track : response) {
-                if (i == 2)
-                    break;
-
+            if (track.isNowPlaying()) {
                 embedBuilder.appendField("Künstler", track.getArtist(), true);
                 embedBuilder.appendField("Titel", track.getName(), true);
                 embedBuilder.appendField("Album", track.getAlbum(), false);
                 embedBuilder.withThumbnail(track.getImageURL(ImageSize.LARGE));
-                i++;
+                DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
+            } else {
+                DiscordIO.sendMessage(message.getChannel(), ":x: Du hörst gerade nichts.");
             }
-
-            DiscordIO.sendEmbed(message.getChannel(), embedBuilder.build());
         } catch (JSONException ex) {
             DiscordIO.sendMessage(message.getChannel(), String.format(":x: Du hast noch keinen Last.fm-Usernamen gesetzt. '%slastfm help' für Hilfe.", botPrefix));
         }
@@ -555,7 +552,7 @@ public class LastFm {
                     try {
                         albumImg = ImageIO.read(new URL(album.getImageURL(ImageSize.LARGE)));
                     } catch (Exception ex) {
-                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead", ex);
+                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead");
                         albumImg = errorImg;
                     }
 
@@ -603,7 +600,7 @@ public class LastFm {
                     try {
                         albumImg = ImageIO.read(new URL(album.getImageURL(ImageSize.LARGE)));
                     } catch (Exception ex) {
-                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead", ex);
+                        LOG.info("Bad url while fetching album image for collage generation - putting in error image instead");
                         albumImg = errorImg;
                     }
 


### PR DESCRIPTION
After an admin sets a Last.fm API Key obtained from here: **https://www.last.fm/api/account/create** , users can use this module to get information from their Last.fm accounts.

Users will have to set their username with [p]lastfm set <last.fm username> These names are saved in the `data\lastFm\lastFm.json` file associated by Discord Account ID.

### Available commands/parameters for [p]lastfm

General:

now - Shows currently playing track

Charts:

recenttracks
toptracks
topartists
topalbums
weeklyartists
weeklytracks
weeklyalbums

Weekly chart collage (generates a png based on provided options) :

collage <artists|albums> <3x3|4x4|5x5>